### PR TITLE
Add LG G Flex KDDI MODEL

### DIFF
--- a/loki_patch.c
+++ b/loki_patch.c
@@ -269,6 +269,14 @@ struct target targets[] = {
 		.lg = 1,
 	},
 	{
+		.vendor = "KDDI",
+		.device = "LG G Flex",
+		.build = "LGL2310d",
+		.check_sigs = 0xf81261c,
+		.hdr = 0xf8b41c0,
+		.lg = 1,
+	},
+	{
 		.vendor = "International",
 		.device = "LG Optimus F5",
 		.build = "P87510e",


### PR DESCRIPTION
I'd like to add LGL23.
aboot.img(LGL23 v10d):https://www.dropbox.com/s/py9gu00ehhyo2dq/lgl23aboot.img

ABOOT_BASE = 0x0f800000 - 0x28 = 0x0f7fffd8
ABOOT_OFFSET(app/aboot/aboot.c) = 0x000344E0
0x0f7fffd8 + 0x000344E0 = 0x0F8344B8 =>reverse B844830F

E804830F B844830F 38B50446
E804830F B844830F 2DE9F843
E804830F B844830F FEF7BCF8
E804830F B844830F C0418B0F
E804830F B844830F 3C49830F
E804830F B844830F C0418B0F
E804830F B844830F 032A2DE9

C0418B0F =>reverse 0xf8b41c0

PATTERN6 = 2de9f04fadf5217d
PATTERN_OFFSET = 00012644

hdr = 0xf8b41c0
check_sigs = ABOOT_BASE + PATTERN_OFFSET = 0xf7fffd8 + 0x12644 = 0xf81261c
