### PR TITLE
Add LG Optimus G Pro DOCOMO MODEL

### DIFF
--- a/loki_patch.c
+++ b/loki_patch.c
@@ -77,6 +77,14 @@ struct target targets[] = {
 		.lg = 1,
 	},
 	{
+		.vendor = "DoCoMo",
+		.device = "LG Optimus G Pro",
+		.build = "L04E10f",
+		.check_sigs = 0x88f1102c,
+		.hdr = 0x88f54418,
+		.lg = 1,
+	},
+	{
 		.vendor = "AT&T or HK",
 		.device = "LG Optimus G Pro",
 		.build = "E98010g or E98810b",


### PR DESCRIPTION
I'd like to add L-04E(LG Optimus G Pro docomo Model).
aboot.img(L-04E v10f):https://www.dropbox.com/s/t9scuy5ws03e02j/aboot.img

ABOOT_BASE = 0x88f00000 - 0x28 = 0x88efffd8
ANDROID-BOOT!_OFFSET：0x00047420
ABOOT_BASE_LG + ANDROID-BOOT!_OFFSET：0x88f473f8 =>reverse f873f488

18 44 F5 88 F8 73 F4 88 9C 41 F5 88
^^ ^^ ^^ ^^
90 16 F3 88 F8 73 F4 88 4C 16 F3 88
18 44 F5 88 F8 73 F4 88 9C 41 F5 88
^^ ^^ ^^ ^^
39 BF 00 BF F8 73 F4 88 28 33 F3 88
98 41 F5 88 F8 73 F4 88 00 1F F3 88

1844f588 =>reverse 0x88f54418

hdr = 0x88f54418
ABOOT_BASE_LG+PATTERN4_OFFSET=>check_sigs：0x88f1102c
