### PR TITLE
Add Optimus it L05E

### DIFF
--- a/loki_patch.c
+++ b/loki_patch.c
@@ -78,6 +78,14 @@ struct target targets[] = {
 	},
 	{
 		.vendor = "DoCoMo",
+		.device = "LG Optimus it L05E",
+		.build = "L05E10d",
+		.check_sigs = 0x88f1157c,
+		.hdr = 0x88f31e10,
+		.lg = 1,
+	},
+	{
+		.vendor = "DoCoMo",
 		.device = "LG Optimus G Pro",
 		.build = "L04E10f",
 		.check_sigs = 0x88f1102c,


### PR DESCRIPTION
I'd like to add Optimus it L05E
aboot.img(L05E v10d): http://www.mediafire.com/download/u3fqwa52a1ky7uz/l05e10d_aboot.img

ABOOT_BASE:0x88efffd8
ANDROID-BOOT!_OFFSET:0x00047CC4
ABOOT_BASE_LG + ANDROID-BOOT!_OFFSET：0x88f47c9c =>reverse 0x9c7cf488

9C41F588 9C7CF488 B01DF388
101EF388 9C7CF488 B01EF388
101EF388 9C7CF488 8C1DF388
D5BE00BF 9C7CF488 F8EFF288
9841F588 9C7CF488 5826F388


101EF388 =>reverse 0x88f31e10

PATTERN4:0x2de9f04fadf5c66d
PATTERN4_OFFSET:0x000115a4
0x000115a4 + 0x88efffd8 = 0x88f1157c

check_signs = 0x88f1157c
hdr = 0x88f31e10
